### PR TITLE
Use `property` not `name` in run script

### DIFF
--- a/sharry/rootfs/etc/services.d/sharry/run
+++ b/sharry/rootfs/etc/services.d/sharry/run
@@ -28,7 +28,7 @@ for var in $(bashio::config 'conf_overrides|keys'); do
     else
         bashio::log.info "Setting ${property} to ${value}"
     fi
-    conf_props+=("-D${name}=${value//\"/\\\"}")
+    conf_props+=("-D${property}=${value//\"/\\\"}")
 done
 
 # Set DB URL


### PR DESCRIPTION
Another leftover from Hedgedoc. Using `name` but should be `property` when setting up `conf_overrides`