### PR TITLE
Auth command fails on error HTTP status

### DIFF
--- a/sharry/rootfs/etc/sharry/sharry.conf
+++ b/sharry/rootfs/etc/sharry/sharry.conf
@@ -108,11 +108,13 @@ sharry.restserver {
         enabled = true
         program = [
           "curl"
+          "--fail"
           "--user"
           "{{user}}:{{pass}}"
           "--header"
           "X-Supervisor-Token: "${SUPERVISOR_TOKEN}""
           "http://supervisor/auth"
+        
         ]
         # the return code to consider successful verification
         success = 0


### PR DESCRIPTION
Normally curl always returns success status unless it cannot connect, not good for an auth command. Add `--fail` so it returns non-zero status if HTTP status code is 4xx or 5xx.