### PR TITLE
Add watchdog URL to config

### DIFF
--- a/sharry/config.json
+++ b/sharry/config.json
@@ -8,6 +8,7 @@
   "services": ["mysql:want"],
   "auth_api": true,
   "webui": "http://[HOST]:[PORT:9090]",
+  "watchdog": "http://[HOST]:9090/api/v2/open/info/version",
   "ports": {
     "9090/tcp": 9090
   },


### PR DESCRIPTION
Add URL to Sharry's version API (`/api/v2/open/info/version`) for watchdog to monitor.