### PR TITLE
Silent curl to prevent log noise during auth

### DIFF
--- a/sharry/rootfs/etc/sharry/sharry.conf
+++ b/sharry/rootfs/etc/sharry/sharry.conf
@@ -109,6 +109,7 @@ sharry.restserver {
         program = [
           "curl"
           "--fail"
+          "--silent"
           "--user"
           "{{user}}:{{pass}}"
           "--header"


### PR DESCRIPTION
Add `--silent` to curl command used for auth to strip out the log noise that happens with curl calls.