### PR TITLE
Move `curl` call into a script to simplify auth

### DIFF
--- a/sharry/rootfs/etc/sharry/sharry.conf
+++ b/sharry/rootfs/etc/sharry/sharry.conf
@@ -107,15 +107,9 @@ sharry.restserver {
       command {
         enabled = true
         program = [
-          "curl"
-          "--fail"
-          "--silent"
-          "--user"
-          "{{user}}:{{pass}}"
-          "--header"
-          "X-Supervisor-Token: "${SUPERVISOR_TOKEN}""
-          "http://supervisor/auth"
-        
+          "/usr/bin/ha_auth"
+          "{{user}}"
+          "{{pass}}"
         ]
         # the return code to consider successful verification
         success = 0

--- a/sharry/rootfs/usr/bin/ha_auth
+++ b/sharry/rootfs/usr/bin/ha_auth
@@ -1,0 +1,7 @@
+#!/bin/bash
+curl \
+  --fail \
+  --silent \
+  --user "$1:$2" \
+  --header "X-Supervisor-Token: ${SUPERVISOR_TOKEN}" \
+  http://supervisor/auth


### PR DESCRIPTION
Move actual curl call to do auth with HA into a small script. Doesn't change any functionality but simplifies the config and allows me to lock it down better with apparmor later.