### PR TITLE
aa - no `**` in peer filtering for signal directive

### DIFF
--- a/sharry/apparmor.txt
+++ b/sharry/apparmor.txt
@@ -12,10 +12,8 @@ profile sharry flags=(attach_disconnected,mediate_deleted) {
   include <abstractions/base>
   include <abstractions/bash>
 
-  # Signalling - Receive from above, signal children and ourselves
-  signal (receive) peer=unconfined,
-  signal (send) peer=@{profile_name}//**,
-  signal peer=@{profile_name},
+  # Send signals to child services
+  signal (send) peer=@{profile_name}//*,
 
   # Capabilities to run service as non-root
   capability kill,
@@ -71,10 +69,8 @@ profile sharry flags=(attach_disconnected,mediate_deleted) {
   profile sharry-java flags=(attach_disconnected,mediate_deleted) {
     include <abstractions/base>
 
-    # Signalling - receive from above, signal ourselves
-    signal (receive) peer=unconfined,
+    # Receive signals from s6
     signal (receive) peer=*_sharry,
-    signal peer=@{profile_name},
 
     # Network access
     network tcp,


### PR DESCRIPTION
Appears you can't use `**` in peer filter for signal directive. So instead adjusting to use named child profiles and a single `*` when s6 needs to be able to signal the child process.