### PR TITLE
Bump mariadb-client from 10.5.8-r0 to 10.5.9-r0

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -26,7 +26,7 @@ FROM ${BUILD_FROM}
 RUN set -eux; \
     apk update; \
     apk add --no-cache \
-        mariadb-client=10.5.8-r0 \
+        mariadb-client=10.5.9-r0 \
         netcat-openbsd=1.130-r2 \
         openjdk11-jre=11.0.9_p11-r1 \
         ; \


### PR DESCRIPTION
Bump `mariadb-client` alpine package to latest version