### PR TITLE
Bump addons base from `9.1.7` to `9.2.0`

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -1,5 +1,4 @@
-# https://github.com/hassio-addons/addon-base/releases
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.7
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 
 # https://hub.docker.com/_/alpine
 FROM alpine:3.13.4 as build
@@ -20,8 +19,8 @@ RUN set -eux; \
     rm /tmp/sharry.zip;
 
 
-# hadolint ignore=DL3006
-FROM ${BUILD_FROM}
+# https://github.com/hassio-addons/addon-base/releases
+FROM ${BUILD_FROM}:9.2.0
 
 RUN set -eux; \
     apk update; \

--- a/sharry/build.json
+++ b/sharry/build.json
@@ -1,6 +1,6 @@
 {
   "build_from": {
-    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.7",
-    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.7"
+    "amd64": "ghcr.io/hassio-addons/base/amd64",
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64"
   }
 }


### PR DESCRIPTION
Bumps hassio-addons/addon-base image from `9.1.7` to [9.2.0](https://github.com/hassio-addons/addon-base/releases/tag/v9.2.0)