### PR TITLE
Run CI nightly to check packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ name: CI
 
 # yamllint disable-line rule:truthy
 on:
+  schedule:
+    - cron: "0 4 * * *"
   push:
     branches:
       - main


### PR DESCRIPTION
Run CI workflow nightly since it will get an error if a new version of an alpine or debian package has been released.