### PR TITLE
Bump sharry to `1.7.1`

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 # https://hub.docker.com/_/alpine
 FROM alpine:3.13.5 as build
 # https://github.com/eikek/sharry/releases
-ENV SHARRY_VERSION=1.7.0
+ENV SHARRY_VERSION=1.7.1
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Bump Sharry from `1.7.0` to [1.7.1](https://github.com/eikek/sharry/releases/tag/v1.7.1). Very minor bump, fixes one bug.