### PR TITLE
Update to Sharry `1.8.0`

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 # https://hub.docker.com/_/alpine
 FROM alpine:3.13.5 as build
 # https://github.com/eikek/sharry/releases
-ENV SHARRY_VERSION=1.7.1
+ENV SHARRY_VERSION=1.8.0
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Update Sharry from `1.7.1` to [1.8.0](https://github.com/eikek/sharry/releases/tag/v1.8.0).

Note that the release notes do list some breaking changes. Make sure release notes encourage users to review these.