### PR TITLE
Bump addon base to `9.2.1`

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:9.2.0
+FROM ${BUILD_FROM}:9.2.1
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Bump addon base from `9.2.0` to [9.2.1](https://github.com/hassio-addons/addon-base/releases/tag/v9.2.1)