### PR TITLE
Bump addon base to `10.0.0`

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -8,7 +8,7 @@ ENV SHARRY_VERSION=1.8.0
 RUN set -eux; \
     apk update; \
     apk add --no-cache --virtual .build-deps \
-        unzip=6.0-r8 \
+        unzip=6.0-r9 \
         curl=7.77.0-r1 \
         ; \
     mkdir -p /opt; \
@@ -27,7 +27,7 @@ RUN set -eux; \
     apk add --no-cache \
         mariadb-client=10.5.9-r0 \
         netcat-openbsd=1.130-r2 \
-        openjdk11-jre=11.0.9_p11-r1 \
+        openjdk11-jre=11.0.11_p9-r0 \
         ; \
     java -version; \
     \

--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:9.2.2
+FROM ${BUILD_FROM}:10.0.0
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Bump addon base from `9.2.2` to [10.0.0](https://github.com/hassio-addons/addon-base/releases/tag/v10.0.0). Also requires updates to following packages:
- unzip to `6.0-r9`
- openjdk11-jre to `11.0.11_p9-r0`