### PR TITLE
Bump addon base to `10.2.0`

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:10.1.1
+FROM ${BUILD_FROM}:10.2.0
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Bump addon base from `10.1.1` to [10.2.0](https://github.com/hassio-addons/addon-base/releases/tag/v10.2.0)