### PR TITLE
Add access to ssl1.1 cnf file

### DIFF
--- a/sharry/apparmor.txt
+++ b/sharry/apparmor.txt
@@ -40,7 +40,7 @@ profile sharry flags=(attach_disconnected,mediate_deleted) {
   @{do_run}/**                                        rwk,
   /dev/tty                                            rw,
   @{do_usr}/lib/locale/{,**}                          r,
-  @{do_etc}/ssl/openssl.cnf                           r,
+  @{do_etc}/ssl{,1.1}/openssl.cnf                     r,
   @{do_etc}/{group,hosts,passwd,resolv.conf}          r,
   /dev/null                                           k,
 
@@ -89,7 +89,7 @@ profile sharry flags=(attach_disconnected,mediate_deleted) {
 
     # Authenticate with HA
     /usr/bin/curl                                     rix,
-    @{do_etc}/ssl/openssl.cnf                         r,
+    @{do_etc}/ssl{,1.1}/openssl.cnf                   r,
     @{do_etc}/{hosts,passwd,resolv.conf}              r,
 
     # Runtime usage


### PR DESCRIPTION
Sharry needs access to `/etc/ssl1.1/openssl.cnf` now, adding that to AA profile.
