### PR TITLE
Bump mariadb-client and openjdk11-jre

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -25,7 +25,7 @@ FROM ${BUILD_FROM}:11.0.1
 RUN set -eux; \
     apk update; \
     apk add --no-cache \
-        mariadb-client=10.6.4-r2 \
+        mariadb-client=10.6.7-r0 \
         netcat-openbsd=1.130-r3 \
         openjdk11-jre=11.0.14_p9-r0 \
         ; \

--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -27,7 +27,7 @@ RUN set -eux; \
     apk add --no-cache \
         mariadb-client=10.6.7-r0 \
         netcat-openbsd=1.130-r3 \
-        openjdk11-jre=11.0.14_p9-r0 \
+        openjdk11-jre=11.0.15_p10-r0 \
         ; \
     java -version; \
     \


### PR DESCRIPTION
Bump the following packages:
- mariadb-client from `10.6.4-r2` to `10.6.7-r0`
- openjdk11-jre from `11.0.14_p9-r0` to `11.0.15_p10-r0`