### PR TITLE
Update Sharry to `1.10.0`

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 # https://hub.docker.com/_/alpine
 FROM alpine:3.15.4 as build
 # https://github.com/eikek/sharry/releases
-ENV SHARRY_VERSION=1.9.0
+ENV SHARRY_VERSION=1.10.0
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Update Sharry from `1.9.0` to [1.10.0](https://github.com/eikek/sharry/releases/tag/v1.10.0)
