### PR TITLE
Bump hassio-addons/base to `11.1.2`

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:11.0.1
+FROM ${BUILD_FROM}:11.1.2
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Bump hassio-addons/base from `11.0.1` to [11.1.2](https://github.com/hassio-addons/addon-base/releases/tag/v11.1.2)
