### PR TITLE
Revert "Update Sharry to `1.10.0`"

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -3,7 +3,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 # https://hub.docker.com/_/alpine
 FROM alpine:3.15.4 as build
 # https://github.com/eikek/sharry/releases
-ENV SHARRY_VERSION=1.10.0
+ENV SHARRY_VERSION=1.9.0
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Reverts mdegat01/addon-sharry#95

Can't update to 1.10.0 until https://github.com/eikek/sharry/issues/766 is fixed as most users will be using this in conjunction with the MariaDB addon.