### PR TITLE
Update sharry from 1.9.0 to 1.11.0

### DIFF
--- a/sharry/build.yaml
+++ b/sharry/build.yaml
@@ -6,4 +6,4 @@ codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com
 args:
-  SHARRY_VERSION: 1.9.0
+  SHARRY_VERSION: 1.11.0


### PR DESCRIPTION
Update sharry from `1.9.0` to [1.11.0](https://github.com/eikek/sharry/releases/tag/v1.11.0)