### PR TITLE
Ensure log level setting used for all loggers

### DIFF
--- a/sharry/rootfs/etc/services.d/sharry/run
+++ b/sharry/rootfs/etc/services.d/sharry/run
@@ -89,7 +89,7 @@ fi
 # --- SET LOG LEVEL ---
 # Can't be set with arguments or env variables, search & replace config file
 case "$(bashio::config 'log_level')" in \
-    trace)      log_level='Trace';& \
+    trace)      log_level='Trace' ;; \
     debug)      log_level='Debug' ;; \
     notice)     ;& \
     warning)    log_level='Warn' ;; \

--- a/sharry/rootfs/etc/sharry/sharry.conf
+++ b/sharry/rootfs/etc/sharry/sharry.conf
@@ -23,7 +23,16 @@ sharry.restserver {
 
     # The minimum level to log. From lowest to highest:
     # Trace, Debug, Info, Warn, Error
-    minimum-level = "Warn"
+    #### CANNOT OVERRIDE 
+    minimum-level = "Info"
+  
+    # Override the log level of specific loggers
+    levels = {
+      "sharry" = ${sharry.restserver.logging.minimum-level}
+      "org.flywaydb" = ${sharry.restserver.logging.minimum-level}
+      "binny" = ${sharry.restserver.logging.minimum-level}
+      "org.http4s" = ${sharry.restserver.logging.minimum-level}
+    }
   }
 
   # The time from receiving a request until the first line of the


### PR DESCRIPTION
Seems the logger overrides listed [here](https://eikek.github.io/sharry/doc/configure#default-config) take effect. Overriding them back to the minimum level with subsitutions so the log level option is used for all loggers.