### PR TITLE
Bump addon base to `12.2.3`

### DIFF
--- a/sharry/Dockerfile
+++ b/sharry/Dockerfile
@@ -23,9 +23,9 @@ RUN set -eux; \
     apk del .build-deps; \
     \
     apk add --no-cache \
-        mariadb-client=10.6.8-r0 \
+        mariadb-client=10.6.9-r0 \
         netcat-openbsd=1.130-r3 \
-        openjdk11-jre=11.0.15_p10-r1 \
+        openjdk11-jre=11.0.16.1_p1-r0 \
         ; \
     java -version; \
     \

--- a/sharry/build.yaml
+++ b/sharry/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/base:12.2.0
-  aarch64: ghcr.io/hassio-addons/base:12.2.0
+  amd64: ghcr.io/hassio-addons/base:12.2.3
+  aarch64: ghcr.io/hassio-addons/base:12.2.3
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com


### PR DESCRIPTION
Bump addon base from [12.2.0 to 12.2.3](https://github.com/hassio-addons/addon-base/compare/v12.2.0...v12.2.3)