### PR TITLE
Set exit code in finish script

### DIFF
--- a/sharry/rootfs/etc/services.d/sharry/finish
+++ b/sharry/rootfs/etc/services.d/sharry/finish
@@ -3,8 +3,12 @@
 # Take down the S6 supervision tree when Sharry fails
 # s6-overlay docs: https://github.com/just-containers/s6-overlay
 # ==============================================================================
-if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
-  bashio::log.warning "Halt add-on"
+
+declare APP_EXIT_CODE=${1}
+
+if [[ "${APP_EXIT_CODE}" -ne 0 ]] && [[ "${APP_EXIT_CODE}" -ne 256 ]]; then
+  bashio::log.warning "Halt add-on with exit code ${APP_EXIT_CODE}"
+  echo "${APP_EXIT_CODE}" > /run/s6-linux-init-container-results/exitcode
   exec /run/s6/basedir/bin/halt
 fi
 


### PR DESCRIPTION
Properly set exit code when finish script halts the addon.
